### PR TITLE
CUDF gpu memory management #17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ mapdql_history.txt
 **/.DS_Store
 
 .vscode/
+tmp/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,85 @@
+SHELL = /bin/sh
+.DEFAULT_GOAL=all
+
+DB_CONTAINER = omnisci_test
+PYTHON = 3.8
+OMNISCI_VERSION = v5.8.0
+# OMNISCI_VERSION = latest
+
+-include .env
+
+init:
+	mamba env create -f ./environment.yml
+
+init.gpu:
+	mamba env create -f ./environment_gpu.yml
+
+update:
+	mamba env update -f ./environment.yml
+
+update.gpu:
+	mamba env update -f ./environment_gpu.yml
+
 develop:
 	pip install -e '.[dev]'
 	pre-commit install
+
+start:
+	docker run -d --rm --name ${DB_CONTAINER} \
+		--ipc=host \
+		-p ${OMNISCI_DB_PORT}:6274 \
+		-p ${OMNISCI_DB_PORT_HTTP}:6278 \
+		omnisci/core-os-cpu:${OMNISCI_VERSION} \
+		/omnisci/startomnisci --non-interactive \
+		--data /omnisci-storage/data --config /omnisci-storage/omnisci.conf \
+		--enable-runtime-udf --enable-table-functions
+.PHONY: start
+
+start.gpu:
+	docker run -d --rm --name ${DB_CONTAINER} \
+		--ipc=host \
+		--gpus=0 \
+		-p ${OMNISCI_DB_PORT}:6274 \
+		-p ${OMNISCI_DB_PORT_HTTP}:6278 \
+		omnisci/core-os-cuda:${OMNISCI_VERSION} \
+		/omnisci/startomnisci --non-interactive \
+		--data /omnisci-storage/data --config /omnisci-storage/omnisci.conf \
+		--enable-runtime-udf --enable-table-functions
+.PHONY: start.gpu
+
+stop:
+	docker stop ${DB_CONTAINER}
+.PHONY: stop
+
+down:
+	docker rm -f ${DB_CONTAINER}
+.PHONY: down
+
+install:
+	pip install -e .
+.PHONY: install
+
+build:
+	python setup.py build
+	# pip install -e .
+.PHONY: build
+
+check:
+	pre-commit
+	# black .
+	# flake8
+ .PHONY: check
+
+test:
+	pytest
+.PHONY: test
+
+clean:
+	python setup.py clean
+.PHONY: clean
+
+test_all: init start check test down clean
+.PHONY: test_all
+
+all: build
+.PHONY: all

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -134,6 +134,39 @@ You also need to `install cudf`_ in your development environment. Because cudf i
 to the specific version of CUDA installed, we recommend checking the `cudf documentation`_ to get the most up-to-date
 installation instructions.
 
+************************
+Makefile commands
+************************
+
+Instead of using the commands above, the ``Makefile`` contains a number of these as shortcuts for automation.
+
+For example:
+
+.. code-block:: shell
+
+   # Create the conda environment
+   make init
+   activate omnisci-dev
+   make develop
+
+   # Validate code
+   make check
+
+   # Start the OmniSci DB in docker
+   make start
+   # Or, start OmniSci DB in docker with GPU
+   make start.gpu
+
+   # Run tests
+   make test
+
+   # build
+   make build
+
+   # Stop database
+   make down
+
+
 -------------------------------
 Updating Apache Thrift Bindings
 -------------------------------

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 - defaults
 dependencies:
 - pandas
-- pyarrow==3.0.0
+- pyarrow>=3.0.0
 - thrift<=0.14.0
 - pandas
 - python >=3.7.0,<3.9

--- a/environment_gpu.yml
+++ b/environment_gpu.yml
@@ -8,7 +8,8 @@ dependencies:
 - cudf>=0.16
 - cudatoolkit=11.0
 - python >=3.7.0,<3.9
-- pyarrow<=3.0.0
+- pyarrow>=3.0.0
+- thrift<=0.14.0
 - pandas
 - geopandas
 - shapely
@@ -17,6 +18,7 @@ dependencies:
 - numpydoc
 - coverage
 - flake8
+- black
 - pre-commit
 - pytest-cov
 - pytest-mock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools", "wheel", "pip"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 79
 skip-string-normalization = true

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -151,7 +151,7 @@ test_pyomnisci() {
         --interactive \
         --network="net_pyomnisci" \
         --workdir="/pyomnisci" \
-        --env OMNISCI_HOST="${db_container_name}" \
+        --env OMNISCI_DB_HOST="${db_container_name}" \
         --name "${testscript_container_name}" \
         $test_image_name \
         /pyomnisci/ci/build-conda.sh "$*"

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 install_requires = [
-    'pyarrow == 3.0.0',
-    'pyomniscidb >=5.5.0',
+    'pyarrow >= 3.0.0',
+    'pyomniscidb >= 5.6',
     'shapely',
     'sqlalchemy >= 1.3',
     'pandas',


### PR DESCRIPTION
Allow config OMNISCI_DB_HOST and OMNISCI_DB_PORT for testing.

pyarrow>=3.0.0 and thrift<=0.14.0
in environment_gpu.yml and environment.yml
to be consistent with cudf (pyarrow 5.0.0)

Fix test_invalid_sql because error message
from DB has changed.

pyproject.toml build reqs so pip install works.

Add a Makefile for other common commands.