### PR TITLE
Update heavyai for pyheavydb 10.0.0

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -5,7 +5,6 @@ channels:
 dependencies:
 - python >=3.7.0
 - pyarrow>=3.0.0
-- thrift >=0.13
 - sqlalchemy  # 3.10 issue with one of its dependency if pip
 - pandas
 - geopandas

--- a/ci/environment_gpu.yml
+++ b/ci/environment_gpu.yml
@@ -9,7 +9,6 @@ dependencies:
 - cudatoolkit
 - python >=3.7.0
 - pyarrow>=3.0.0=*cuda
-- thrift >=0.13
 - sqlalchemy  # 3.10 issue with one of its dependency if pip
 - pandas
 - geopandas

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -134,26 +134,19 @@ You also need to `install cudf`_ in your development environment. Because cudf i
 to the specific version of CUDA installed, we recommend checking the `cudf documentation`_ to get the most up-to-date
 installation instructions.
 
--------------------------------
-Updating Apache Thrift Bindings
--------------------------------
+------------------------------------
+Updating Apache Thrift Compatibility
+------------------------------------
 
-When the upstream `HeavyDB`_ project updates its Apache Thrift definition file, the bindings shipped with
-``heavyai`` need to be regenerated. Note that the `heavydb` repository must be cloned locally.
+``heavyai`` does not ship generated Apache Thrift bindings. They are generated
+and packaged by `pyheavydb`_ from the HeavyDB IDL snapshot in that repository.
 
-.. code-block:: shell
+When the upstream `HeavyDB`_ project updates either its IDL or Thrift toolchain,
+update, test, and release `pyheavydb`_. No generated bindings or direct Thrift
+version change is needed in this repository. Raise the minimum ``pyheavydb``
+version only when ``heavyai`` requires that new client baseline, then run the
+full test suite against the new wheel. Do not copy ``gen-py`` output here.
 
-   # Clone the heavydb repository
-   git clone https://github.com/heavyai/heavydb
-
-   # Ensure you are at the root of the heavydb directory.
-   cd ./heavydb
-
-   # Use Thrift to generate the Python bindings
-   thrift -gen py -r heavy.thrift
-
-   # Copy the generated bindings to the heavyai root
-   cp -r ./gen-py/heavydb/* ../heavyai/heavydb/
 
 
 --------------------------
@@ -217,6 +210,7 @@ nothing that needs to be done to speed this up, just be patient.
 When the conda-forge bot opens a PR on the heavyai-feedstock repo, one of the feedstock maintainers needs to validate the correctness
 of the PR, check the accuracy of the package versions on the `meta.yaml`_ recipe file, and then merge once the CI tests pass.
 
+.. _pyheavydb: https://github.com/heavyai/pyheavydb
 .. _HeavyDB: https://github.com/heavyai/heavydb
 .. _Docker: https://hub.docker.com/u/heavyai
 .. _CPU image: https://hub.docker.com/r/heavyai/core-os-cpu

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "heavyai"
-version = "1.3.1"
+version = "10.0.0"
 requires-python = ">=3.10"
 authors = [{name = "Heavy.AI", email = "community@heavy.ai"}]
 description = "Data science toolkit support for HeavyDB"
 readme = "README.md"
-license = {file = "LICENSE.md"}
+license = {file = "LICENSE.txt"}
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Topic :: Database",


### PR DESCRIPTION
* Release heavyai 10.0.0 against pyheavydb 10.0.0 so installations receive the Thrift 0.24-compatible client.

* Make pyheavydb the single Thrift compatibility boundary and remove redundant direct Thrift constraints from HeavyAI development environments.

* Correct release metadata and document where future HeavyDB IDL and Thrift toolchain updates belong.

---

Note: This PR depends on [heavyai/pyheavydb#9](https://github.com/heavyai/pyheavydb/pull/9).

Note: The full HeavyAI suite passed against HeavyDB 10 with the local pyheavydb 10.0.0 wheel; 111 tests passed and 14 expected tests were skipped.